### PR TITLE
BUG: Manifest Version not properly assigned, and incorrect label flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,12 +47,8 @@ async function getReleaseVersion(owner, repo, targetAsset) {
   // Pull the latest version of the CLI
   let release = await octokit.repos.getLatestRelease({ owner, repo });
 
-  core.info(`latest release data: ${JSON.stringify(release.data)}`)
-
   let manifestVersion = release.data?.tag_name;
   let binaryUrl = undefined;
-
-  core.info(`version is ${manifestVersion}`)
 
   for (let i = 0; i < release.data?.assets?.length || 0; i++) {
     if (release.data.assets[i].name === targetAsset) {
@@ -64,8 +60,6 @@ async function getReleaseVersion(owner, repo, targetAsset) {
   if (!binaryUrl) {
     throw new Error("Could not find the latest release of the CLI");
   }
-
-  core.info(`returning version ${manifestVersion}`)
 
   return { manifestVersion, binaryUrl };
 }
@@ -223,7 +217,7 @@ try {
               core.warning(`The version of the CLI (${manifestVersion}) does not support the \`--source\` flag. Please upgrade to v0.8.1 or later.`);
             }
             if (mVer && labels && semver.gte(mVer, labelsFlagMinVer)) {
-              publishCommand = `${publishCommand} --labels=${labels.split(" ").join("-")}`;
+              publishCommand = `${publishCommand} --label=${labels.split(" ").join("-")}`;
             } else if (labels) {
               core.warning(`The version of the CLI (${manifestVersion}) does not support the \`--labels\` flag. Please upgrade to v0.9.1 or later.`);
             }

--- a/index.js
+++ b/index.js
@@ -47,10 +47,12 @@ async function getReleaseVersion(owner, repo, targetAsset) {
   // Pull the latest version of the CLI
   let release = await octokit.repos.getLatestRelease({ owner, repo });
 
-  core.info(`latest release data: ${JSON.stringify(release)}`)
+  core.info(`latest release data: ${JSON.stringify(release.data)}`)
 
-  let version = release.data?.tag_name;
+  let manifestVersion = release.data?.tag_name;
   let binaryUrl = undefined;
+
+  core.info(`version is ${manifestVersion}`)
 
   for (let i = 0; i < release.data?.assets?.length || 0; i++) {
     if (release.data.assets[i].name === targetAsset) {
@@ -63,7 +65,9 @@ async function getReleaseVersion(owner, repo, targetAsset) {
     throw new Error("Could not find the latest release of the CLI");
   }
 
-  return { version, binaryUrl };
+  core.info(`returning version ${manifestVersion}`)
+
+  return { manifestVersion, binaryUrl };
 }
 
 // TODO: Add support for caching the CLI

--- a/index.js
+++ b/index.js
@@ -47,6 +47,8 @@ async function getReleaseVersion(owner, repo, targetAsset) {
   // Pull the latest version of the CLI
   let release = await octokit.repos.getLatestRelease({ owner, repo });
 
+  core.info(`latest release data: ${release}`)
+
   let version = release.data?.tag_name;
   let binaryUrl = undefined;
 

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ async function getReleaseVersion(owner, repo, targetAsset) {
   // Pull the latest version of the CLI
   let release = await octokit.repos.getLatestRelease({ owner, repo });
 
-  core.info(`latest release data: ${release}`)
+  core.info(`latest release data: ${JSON.stringify(release)}`)
 
   let version = release.data?.tag_name;
   let binaryUrl = undefined;


### PR DESCRIPTION
```
SBOM Updated
Warning: The version of the CLI (undefined) does not support the `--source` flag. Please upgrade to v0.8.1 or later.
Warning: The version of the CLI (undefined) does not support the `--labels` flag. Please upgrade to v0.9.1 or later.

```


```
Sending request to Manifest Server
node:internal/errors:857
  const err = new Error(message);
              ^

Error: Command failed: MANIFEST_API_KEY=*** manifest publish --ignore-validation=True --paths=manifest_cyber.json --source=github-action --relationship=first --source=github-action --labels=81322328afddd055b95cdfd42f4277b6e8f53bb7,test,label
Error: /11 18:27:36 [ERROR] unknown flag: --labels

    at ChildProcess.exithandler (node:child_process:[40](https://github.com/fianulabs/docs-demo-app/actions/runs/6486529123/job/17614885957#step:3:41)2:12)
    at ChildProcess.emit (node:events:513:28)
    at maybeClose (node:internal/child_process:1100:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:304:5) {
  code: 1,
  killed: false,
  signal: null,
  cmd: 'MANIFEST_API_KEY=*** manifest publish --ignore-validation=True --paths=manifest_cyber.json --source=github-action --relationship=first --source=github-action --labels=81322328afddd055b95cdfd[42](https://github.com/fianulabs/docs-demo-app/actions/runs/6486529123/job/17614885957#step:3:43)f4277b6e8f53bb7,test,label',
  stdout: '',
Error: r: '2023/10/11 18:27:36 [ERROR] unknown flag: --labels\n'
}
```