### PR TITLE
Updates docs to latest, fixes backwards-compat issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,32 +1,33 @@
-name: Main
+name: Generate and Publish SBOM
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:
       - "main"
-    tags:
-      - '*'
-      
+
+
+permissions:
+  id-token: write
+  contents: read # This is required for actions/checkout@v2
+
 jobs:
-  build-sbom:
+  generate-and-publish-sbom:
     runs-on: ubuntu-latest
-    steps: 
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - run: npm install
-      - name: Transmit own SBOM
-        uses: ./ # Uses an action in the root directory
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+
+      # Generate and transmita copy of our generated SBOM to Manifest
+      - name: Generate and Transmit SBOM to Manifest
+        uses: manifest-cyber/manifest-github-action@main
         id: transmit
         with:
+          # Generate an API key at https://app.manifestcyber.com/organization
+          # Store the key as a secret in Github, and reference it below
+          # Do not share this key - this allows the holder to upload SBOM's to Manifest on your behalf
           apiKey: ${{ secrets.MANIFEST_API_KEY }}
-          bomFilePath: ./bom.json
-          # uncomment optional values:
-          # path: ./
-          # sbomName: forced-sbom-name
-          # sbomVersion: 4.2.0
-          # sbomOutput: cyclonedx-json
-          # sbomGenerator: syft
-          # sbomArtifact: true
-          # sbomPublish: true
-          # sbomGeneratorFlags: <FOR_ADVANCED_USERS>

--- a/examples/generate-and-publish.yml
+++ b/examples/generate-and-publish.yml
@@ -59,11 +59,11 @@ jobs:
         id: generate
         with:
           apiKey: ${{ secrets.MANIFEST_API_KEY }}
-          bomGenerator: ${{ env.sbomGenerator }}
-          bomOutput: ${{ env.sbomOutput }}
+          sbomGenerator: ${{ env.sbomGenerator }}
+          sbomOutput: ${{ env.sbomOutput }}
           #relationship: ${{ env.relationship }}
-          #bomName: ${{ env.sbomName }}
+          #sbomName: ${{ env.sbomName }}
           #path: ${{ env.path }}
-          #bomArtifact: ${{ env.sbomArtifact }}
-          #bomVersion: ${{ env.sbomVersion }}
-          #bomLabels: ${{ env.sbomLabels }}
+          #sbomArtifact: ${{ env.sbomArtifact }}
+          #sbomVersion: ${{ env.sbomVersion }}
+          #sbomLabels: ${{ env.sbomLabels }}

--- a/examples/generate.yml
+++ b/examples/generate.yml
@@ -49,10 +49,10 @@ jobs:
         uses: manifest-cyber/manifest-github-action@main
         id: generate
         with:
-          #bomGenerator: ${{ env.sbomGenerator }}
-          #bomOutput: ${{ env.sbomOutput }}
-          #bomGeneratorFlags: ${{ env.sbomGeneratorFlags }}
+          #sbomGenerator: ${{ env.sbomGenerator }}
+          #sbomOutput: ${{ env.sbomOutput }}
+          #sbomGeneratorFlags: ${{ env.sbomGeneratorFlags }}
           #relationship: ${{ env.relationship }}
-          #bomName: ${{ env.sbomName }}
+          #sbomName: ${{ env.sbomName }}
           #path: ${{ env.path }}
-          #bomVersion: ${{ env.sbomVersion }}
+          #sbomVersion: ${{ env.sbomVersion }}

--- a/examples/publish.yml
+++ b/examples/publish.yml
@@ -39,7 +39,7 @@ jobs:
         id: generate
         with:
           apiKey: ${{ secrets.MANIFEST_API_KEY }}
-          bomFilePath: ${{ env.bomFilePath }}
+          sbomFilePath: ${{ env.sbomFilePath }}
           #relationship: ${{ env.relationship }}
-          #bomArtifact: ${{ env.sbomArtifact }}
-          #bomLabels: ${{ env.sbomLabels }}
+          #sbomArtifact: ${{ env.sbomArtifact }}
+          #sbomLabels: ${{ env.sbomLabels }}

--- a/index.js
+++ b/index.js
@@ -138,33 +138,29 @@ async function generateSBOM(targetPath, outputPath, outputFormat, sbomName, sbom
   return outputPath;
 }
 
-
-// TODO: Add support for running the CLI against a local deployment
 try {
-  const apiKey = core.getInput("apiKey");
+  const apiKey = core.getInput('apiKey') || core.getInput('apikey');
   core.setSecret(apiKey);
   const targetPath = core.getInput("path") || `${process.cwd()}`;
   const name =
-    core.getInput("sbomName") ||
-    core.getInput("sbom-name") ||
-    `${process.env.GITHUB_REPOSITORY?.replace(
-      `${process.env.GITHUB_REPOSITORY_OWNER}/`,
-      "",
-    )}`;
+    core.getInput('sbomName') ||
+    core.getInput('bbomName') ||
+    core.getInput('sbom-name') ||
+    `${process.env.GITHUB_REPOSITORY?.replace(`${process.env.GITHUB_REPOSITORY_OWNER}/`, '')}`
 
-  const bomFilePath = core.getInput("bomFilePath") || `${name}.json`;
+  const bomFilePath = core.getInput("sbomFilePath") || core.getInput("bomFilePath") || `${name}.json`;
   let version =
     core.getInput("sbomVersion") ||
     core.getInput("bomVersion") ||
     core.getInput("sbom-version");
-  const output = core.getInput("sbomOutput") || core.getInput("sbom-output");
-  const generator = core.getInput("sbomGenerator");
-  const artifact = core.getInput("sbomArtifact");
+  const output = core.getInput('sbomOutput') || core.getInput('sbom-output') || core.getInput('bomOutput')
+  const generator = core.getInput('sbomGenerator') || core.getInput('bomGenerator');
+  const artifact = core.getInput('sbomArtifact') || core.getInput('bomArtifact')
   const publish = core.getInput("sbomPublish");
   const generatorFlags = core.getInput("sbomGeneratorFlags");
   const source = core.getInput("source");
   const relationship = core.getInput("relationship");
-  const labels = core.getInput("sbomLabels") || "";
+  const labels = core.getInput('sbomLabels') || core.getInput('bomLabels') || ''
 
   const targetManifestAsset =
     localTest && localTest === "enabled" ? "manifest_darwin_x86_64.tar.gz" : "manifest_linux_x86_64.tar.gz";
@@ -234,4 +230,3 @@ try {
 catch (error) {
   core.setFailed(error.message);
 }
-

--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ try {
   const targetPath = core.getInput("path") || `${process.cwd()}`;
   const name =
     core.getInput('sbomName') ||
-    core.getInput('bbomName') ||
+    core.getInput('bomName') ||
     core.getInput('sbom-name') ||
     `${process.env.GITHUB_REPOSITORY?.replace(`${process.env.GITHUB_REPOSITORY_OWNER}/`, '')}`
 
@@ -156,8 +156,8 @@ try {
   const output = core.getInput('sbomOutput') || core.getInput('sbom-output') || core.getInput('bomOutput')
   const generator = core.getInput('sbomGenerator') || core.getInput('bomGenerator');
   const artifact = core.getInput('sbomArtifact') || core.getInput('bomArtifact')
-  const publish = core.getInput("sbomPublish");
-  const generatorFlags = core.getInput("sbomGeneratorFlags");
+  const publish = core.getInput('sbomPublish') || core.getInput('bomPublish');
+  const generatorFlags = core.getInput('sbomGeneratorFlags') || core.getInput('bomGeneratorFlags')
   const source = core.getInput("source");
   const relationship = core.getInput("relationship");
   const labels = core.getInput('sbomLabels') || core.getInput('bomLabels') || ''


### PR DESCRIPTION
- Attempts to address some backwards-compat issues related to var names with `(s)bom` prefix. Most vars can now be accessed with both `sbomX` and `bomX` (former is preferred). Some vars that never previously had the `bom` prefix have not been changed/modified. Users using either `sbomX` or `bomX` should experience no interruptions.
- Updates docs and examples to show latest (and be more consistent)