### PR TITLE
mfst-3244/update-github-action-to-support-gh-api-token

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,13 @@ ADVANCED USERS: Flags the Manifest CLI passes through to the generator.
 set the SBOM as active. Expects either `true` or `false`.
 Default: `true`.
 
+### `githubToken`
+
+**Optional**
+`{STRING}`
+
+The action fetches necessary Github releases from the Github Releases API. If you run into rate limit warnings from Github, the action can use a Github API token with authenticating (which may increase your rate limit beyond public limits).
+
 ---
 
 ## Usage

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const manifestBinary = "manifest-cli";
 const jqBinary = "jq";
 const tmpPath = "/tmp";
 
-const githubApiToken = core('githubToken') || core('githubToken') || process.env.GITHUB_TOKEN || undefined;
+const githubApiToken = core('githubToken') || core('githubtoken') || process.env.GITHUB_TOKEN || undefined;
 const octokit = new Octokit({
   auth: githubApiToken,
 });
@@ -71,7 +71,6 @@ async function getReleaseVersion(owner, repo, targetAsset) {
   return { manifestVersion, binaryUrl };
 }
 
-// TODO: Add support for caching the CLI
 async function getCLI(version, url, binary) {
   const dest = `${tmpPath}${url.substring(url.lastIndexOf("/"))}`;
   const binaryPath = `${tmpPath}/${binary}`;

--- a/index.js
+++ b/index.js
@@ -6,16 +6,18 @@ const artifactClient = new DefaultArtifactClient();
 const { exec } = require("child_process");
 const util = require("node:util");
 const semver = require("semver");
-
 const { Octokit } = require("@octokit/rest");
-const octokit = new Octokit({
-  auth: core('githubToken') || core('githubToken') || process.env.GITHUB_TOKEN || undefined,
-});
+
 const manifestOwner = "manifest-cyber";
 const manifestRepo = "cli";
 const manifestBinary = "manifest-cli";
 const jqBinary = "jq";
 const tmpPath = "/tmp";
+
+const githubApiToken = core('githubToken') || core('githubToken') || process.env.GITHUB_TOKEN || undefined;
+const octokit = new Octokit({
+  auth: githubApiToken,
+});
 
 const execPromise = util.promisify(exec);
 
@@ -81,7 +83,11 @@ async function getCLI(version, url, binary) {
 
   if (!fileExists(dest)) {
     core.info(`Downloading the latest version of the CLI from ${url}`);
-    await cache.downloadTool(url, dest);
+    await cache.downloadTool(
+      url,
+      dest,
+      githubApiToken ? `token ${githubApiToken}` : undefined
+    );
   } else {
     core.info("CLI tarball already exists, skipping download");
   }

--- a/index.js
+++ b/index.js
@@ -8,12 +8,12 @@ const util = require("node:util");
 const semver = require("semver");
 
 const { Octokit } = require("@octokit/rest");
-const octokit = new Octokit();
+const octokit = new Octokit({
+  auth: core('githubToken') || core('githubToken') || process.env.GITHUB_TOKEN || undefined,
+});
 const manifestOwner = "manifest-cyber";
 const manifestRepo = "cli";
 const manifestBinary = "manifest-cli";
-const jqOwner = "jqlang";
-const jqRepo = "jq";
 const jqBinary = "jq";
 const tmpPath = "/tmp";
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest/manifest-github-action",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "main": "index.js",
   "author": "Manifest Cyber",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest/manifest-github-action",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "description": "",
   "main": "index.js",
   "author": "Manifest Cyber",


### PR DESCRIPTION
Currently, this Action fetches binary releases (for the Manifest CLI, and for any applicable SBOM generators) from the Github Releases API via Octokit. By default, this appears to have been using public-access rate limit rules. Customers have indicated they're sometimes hitting rate limits; this change is intended to address that by allowing users to pass in a Github API token to be used instead.

- Adds support for (optionally) passing in a `githubToken` (or reading from `process.env.GITHUB_TOKEN`) to have requests to Github Releases API use a specific API token.
- Removes unused `jqOwner` and `jqRepo` vars
- Updates docs to reflect add'l option