### PR TITLE
fix(cli): Remove Active default [MFST-3327]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     branches:
-      - "main"
+      - "mfst-3327/update-active-flag"
 
 permissions:
   id-token: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     branches:
-      - "mfst-3327/update-active-flag"
+      - "main"
 
 permissions:
   id-token: write
@@ -22,9 +22,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: generate SBOM
-        uses: manifest-cyber/manifest-github-action@mfst-3327/update-active-flag
+        uses: manifest-cyber/manifest-github-action@main
         with:
           apiKey: ${{ secrets.MANIFEST_API_KEY }}
           asset-labels: "github-action, production"
           generator: "syft"
-          active: "false"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     branches:
-      - "main"
+      - "mfst-3327/update-active-flag"
 
 permissions:
   id-token: write
@@ -22,8 +22,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: generate SBOM
-        uses: manifest-cyber/manifest-github-action@main
+        uses: manifest-cyber/manifest-github-action@mfst-3327/update-active-flag
         with:
           apiKey: ${{ secrets.MANIFEST_API_KEY }}
           asset-labels: "github-action, production"
           generator: "syft"
+          active: "false"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: generate SBOM
-        uses: manifest-cyber/manifest-github-action@main
+        uses: manifest-cyber/manifest-github-action@mfst-3327/update-active-flag
         with:
           apiKey: ${{ secrets.MANIFEST_API_KEY }}
           asset-labels: "github-action, production"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,3 +27,4 @@ jobs:
           apiKey: ${{ secrets.MANIFEST_API_KEY }}
           asset-labels: "github-action, production"
           generator: "syft"
+          active: "false"

--- a/README.md
+++ b/README.md
@@ -177,8 +177,7 @@ ADVANCED USERS: Flags the Manifest CLI passes through to the generator.
 **Optional**
 `{STRING}`
 
-set the SBOM as active. Expects either `true` or `false`.
-Default: `true`.
+set the SBOM as active. Expects either `true` or `false`. If no value is provided, the SBOM will default to the organization's default behavior, which is typically `true`.
 
 ### Environment Variable - `GITHUB_TOKEN`
 

--- a/index.js
+++ b/index.js
@@ -233,7 +233,7 @@ try {
 
   const source = core.getInput("source");
   const relationship = core.getInput("relationship");
-  const active = core.getInput("active") || "true";
+  const active = core.getInput("active");
   const assetLabels =
     core.getInput("sbomLabels") ||
     core.getInput("bomLabels") ||

--- a/index.js
+++ b/index.js
@@ -305,7 +305,24 @@ try {
               core.info(`SBOM uploaded to GitHub as an artifact: ${upload}`);
             }
             if (shouldPublish(apiKey, publish)) {
-              let publishCommand = `MANIFEST_API_KEY=${apiKey} ${manifestBinary} publish --ignore-validation="true"  --source="${source}" --relationship="${relationship}" --active="${active}" ${bomFilePath}`;
+              // Add the defaults
+              let publishCommandParts = [
+                `MANIFEST_API_KEY=${apiKey}`,
+                `${manifestBinary}`,
+                `publish`,
+                `--ignore-validation="true"`,
+              ];
+              if (source) {
+                publishCommandParts.push(`--source="${source}"`);
+              }
+              if (relationship) {
+                publishCommandParts.push(`--relationship="${relationship}"`);
+              }
+              if (active) {
+                publishCommandParts.push(`--active="${active}"`);
+              }
+              publishCommandParts.push(bomFilePath);
+              let publishCommand = publishCommandParts.join(" ");
               const mVer = semver.coerce(manifestVersion);
               publishCommand = `${publishCommand} --source="github-action"`;
               publishCommand = `${publishCommand} --asset-label="${assetLabels


### PR DESCRIPTION
Observed as setting published asset as `active` `false` during branch based run:

![Screenshot 2024-09-20 at 4 25 20 PM](https://github.com/user-attachments/assets/1faab433-7a15-42e3-a2ba-fe5df8fec65e)

Action run: https://github.com/manifest-cyber/manifest-github-action/actions/runs/10965800359/job/30452385143