### PR TITLE
fix: add guard to detect if SBOM file was generated correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,7 +179,11 @@ async function generateSBOM(
     core.info(`Installed ${generator}`);
     core.info(`Generating SBOM using: ${generateCommand}`);
     await execWrapper(generateCommand).then(() => {
-      core.info(`SBOM Generated: ${outputPath}`);
+      if (fileExists(outputPath)) {
+        core.info(`SBOM Generated: ${outputPath}`);
+      } else {
+        core.setFailed(`Error generating SBOM: ${outputPath} does not exist.`);
+      }
     });
   });
   return outputPath;


### PR DESCRIPTION
A potential false-positive can happen if the generation step does not generate the output file. Would it be possible to add a check to ensure the output path is generated before proceeding with the update step?

Relates to: https://github.com/manifest-cyber/manifest-github-action/issues/35