### PR TITLE
BLD-253/add-optional-sbomArtifactName-parameter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,3 +27,4 @@ jobs:
           apiKey: ${{ secrets.MANIFEST_API_KEY }}
           asset-labels: "github-action, production"
           generator: "syft"
+          artifactName: "example-artifact-name"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,14 +14,14 @@ permissions:
   contents: read
 
 jobs:
-  generate-and-publish-sbom:
+  generate-sbom:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
 
-      - name: generate SBOM
+      - name: Generate SBOM
         uses: manifest-cyber/manifest-github-action@artifact-logic-adjustments
         with:
           apiKey: ${{ secrets.MANIFEST_API_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   push:
-    branches: ["main", "artifact-logic-adjustments"]
+    branches: ["main"]
     tags: ["v*"]
 
 permissions:
@@ -22,9 +22,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Generate SBOM
-        uses: manifest-cyber/manifest-github-action@artifact-logic-adjustments
+        uses: manifest-cyber/manifest-github-action@main
         with:
           apiKey: ${{ secrets.MANIFEST_API_KEY }}
           asset-labels: "github-action, production"
           generator: "syft"
-          sbomArtifactName: "example-artifact-name"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "artifact-logic-adjustments"]
     tags: ["v*"]
 
 permissions:
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: generate SBOM
-        uses: manifest-cyber/manifest-github-action@main
+        uses: manifest-cyber/manifest-github-action@artifact-logic-adjustments
         with:
           apiKey: ${{ secrets.MANIFEST_API_KEY }}
           asset-labels: "github-action, production"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Generate and Publish SBOM
+name: Generate SBOM
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,4 +27,4 @@ jobs:
           apiKey: ${{ secrets.MANIFEST_API_KEY }}
           asset-labels: "github-action, production"
           generator: "syft"
-          artifactName: "example-artifact-name"
+          sbomArtifactName: "example-artifact-name"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Note that any empty value provided to the input will result in a using the defau
 
 Your Manifest API key. Generate this key in the Manifest Cyber app (https://app.manifestcyber.com), and then store it in your Github repository secrets.
 
+Alternative parameter name: `apikey`
+
 ### `bomFilePath`
 
 **REQUIRED FOR UPLOADING BUT NOT GENERATING** `{STRING}`
@@ -47,6 +49,8 @@ Your Manifest API key. Generate this key in the Manifest Cyber app (https://app.
 The path of the SBOM to upload. This is useful if you are generating the SBOM in a different step (not using this action), and want to upload it (using this action) in a later step.
 
 Accepts CycloneDX or SPDX SBOMs in JSON (recommended), XML, or SPDX tag:value format.
+
+Alternative parameter names: `sbomFilePath`
 
 ### `path`
 
@@ -79,12 +83,16 @@ Accepts any string. Default: `github-action`.
 
 The SBOM name, defaults to repository name.
 
+Alternative parameter names: `bomName`, `name`
+
 ### `sbomVersion`
 
 **Optional**
 `{STRING}`
 
 The SBOM version, defaults to environment variable tag, or commit hash.
+
+Alternative parameter names: `bomVersion`, `version`
 
 ### `sbomOutput`
 
@@ -95,6 +103,8 @@ The SBOM output format, this is needed when passing spdx-json SBOM files.
 
 Default: `cyclonedx-json`.
 
+Alternative parameter names: `sbom-output`, `bomOutput`
+
 ### `sbomGenerator`
 
 **Optional**
@@ -102,6 +112,8 @@ Default: `cyclonedx-json`.
 
 The SBOM generator, defaults to syft. Supports: syft | trivy | cdxgen | sigstore-bom | spdx-sbom-generator | docker-sbom.
 Default: `syft`.
+
+Alternative parameter names: `bomGenerator`, `generator`
 
 ### `generator-version`
 
@@ -136,6 +148,8 @@ Path to custom config file for generator, if supported.
 
 Boolean to publish the SBOM to the Manifest Cyber platform. Expects either `true` or `false`. When unset, the action will upload if an API Key is present.
 
+Alternative parameter names: `bomPublish`, `publish`
+
 ### `sbomLabels`
 
 [DEPREACTED: use `asset-labels` instead]
@@ -143,6 +157,8 @@ Boolean to publish the SBOM to the Manifest Cyber platform. Expects either `true
 `{STRING}`
 
 A comma separated list of labels to apply to the SBOM.
+
+Alternative parameter names: `bomLabels`, `asset-labels`
 
 ### `asset-labels`
 
@@ -171,6 +187,25 @@ A comma separated list of labels to apply to the SBOM product, will only be appl
 `{STRING}`
 
 ADVANCED USERS: Flags the Manifest CLI passes through to the generator.
+
+Alternative parameter names: `bomGeneratorFlags`, `generator-flags`
+
+### `sbomArtifact`
+
+**Optional**
+`{STRING}`
+
+Boolean to upload the SBOM as a GitHub artifact. Expects either `true` or `false`.
+Default: `true`.
+
+Alternative parameter names: `bomArtifact`
+
+### `apiURI`
+
+**Optional**
+`{STRING}`
+
+The URI of the Manifest API. This is useful if you need to use a specific API endpoint.
 
 ### `active`
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,16 @@ Default: `true`.
 
 Alternative parameter names: `bomArtifact`
 
+### `sbomArtifactName`
+
+**Optional**
+`{STRING}`
+
+Custom name for the GitHub artifact when uploading the SBOM. This allows you to specify a unique name to prevent artifact name collisions in your workflow.
+Default: `sbom`.
+
+Alternative parameter names: `bomArtifactName`
+
 ### `apiURI`
 
 **Optional**
@@ -313,6 +323,20 @@ In this example, all depedencies would be installed by the action, generating an
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+### Using custom artifact name
+
+```
+- uses: actions/checkout@v4
+- name: Generate SBOM
+  uses: manifest-cyber/manifest-github-action@main
+  id: generate
+  with:
+    apiKey: ${{ secrets.MANIFEST_API_KEY }}
+    sbomArtifactName: ${{ github.repository_owner }}-${{ github.repository }}-sbom
+```
+
+In this example, the artifact name will include the repository owner and repository name to ensure uniqueness.
 
 ## Local Testing
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ const { DefaultArtifactClient } = require("@actions/artifact");
 const artifactClient = new DefaultArtifactClient();
 const { exec } = require("child_process");
 const util = require("util");
-const semver = require("semver");
 
 const execPromise = util.promisify(exec);
 

--- a/index.js
+++ b/index.js
@@ -181,6 +181,8 @@ async function generateSBOM(
     const generatorPreset = core.getInput("generator-preset") || "";
     const uploadArtifactToGithub =
       core.getInput("sbomArtifact") || core.getInput("bomArtifact") || "true";
+    const artifactName =
+      core.getInput("sbomArtifactName") || core.getInput("bomArtifactName") || "sbom";
     const publish =
       core.getInput("sbomPublish") ||
       core.getInput("bomPublish") ||
@@ -228,7 +230,7 @@ async function generateSBOM(
     // Optionally upload the SBOM as an artifact.
     if (outputPath && uploadArtifactToGithub === "true") {
       const upload = await artifactClient.uploadArtifact(
-        "sbom",
+        artifactName,
         [outputPath],
         path.dirname(outputPath)
       );

--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ async function generateSBOM(
     const generatorPreset = core.getInput("generator-preset") || "";
     const uploadArtifactToGithub =
       core.getInput("sbomArtifact") || core.getInput("bomArtifact") || "true";
-    const artifactName =
+    const githubArtifactName =
       core.getInput("sbomArtifactName") || core.getInput("bomArtifactName") || "sbom";
     const publish =
       core.getInput("sbomPublish") ||
@@ -230,7 +230,7 @@ async function generateSBOM(
     // Optionally upload the SBOM as an artifact.
     if (outputPath && uploadArtifactToGithub === "true") {
       const upload = await artifactClient.uploadArtifact(
-        artifactName,
+        githubArtifactName,
         [outputPath],
         path.dirname(outputPath)
       );

--- a/index.js
+++ b/index.js
@@ -180,8 +180,8 @@ async function generateSBOM(
     const generatorVersion = core.getInput("generator-version") || "";
     const generatorConfig = core.getInput("generator-config") || "";
     const generatorPreset = core.getInput("generator-preset") || "";
-    const artifact =
-      core.getInput("sbomArtifact") || core.getInput("bomArtifact");
+    const uploadArtifactToGithub =
+      core.getInput("sbomArtifact") || core.getInput("bomArtifact") || "true";
     const publish =
       core.getInput("sbomPublish") ||
       core.getInput("bomPublish") ||
@@ -227,7 +227,7 @@ async function generateSBOM(
     );
 
     // Optionally upload the SBOM as an artifact.
-    if (outputPath && artifact === "true") {
+    if (outputPath && uploadArtifactToGithub === "true") {
       const upload = await artifactClient.uploadArtifact(
         "sbom",
         [outputPath],

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "dependencies": {
     "@actions/artifact": "2.2.1",
     "@actions/core": "^1.10.1",
-    "@actions/tool-cache": "^2.0.1",
-    "@types/semver": "^7.5.0"
+    "@actions/tool-cache": "^2.0.1"
   },
   "devDependencies": {
     "cross-env": "^7.0.3"


### PR DESCRIPTION
Adds an optional `sbomArtifactName` parameter that allows users to specify a name when attaching the generated SBOM as a Github artifact. This also serves as a workaround for users calling this action multiple times within the same workflow: [the Github actions/artifact package does not allow for multiple artifacts in a single workflow to share a name](https://github.com/actions/toolkit/blob/main/packages/artifact/README.md#breaking-changes).

Further, updates README to include notes on `sbomArtifact` and `sbomArtifactName` usage.