### PR TITLE
feat: add deactivate-older input [ENG-254]

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -85,6 +85,10 @@ inputs:
     description: "set the SBOM as active. Expects either `true` or `false`."
     required: false
 
+  deactivate-older:
+    description: "Mark previous versions of this asset as inactive when publishing this SBOM. Expects either `true` or `false`."
+    required: false
+
   apiUri:
     description: "set the Manifest API endpoint URI."
     required: false

--- a/index.js
+++ b/index.js
@@ -209,6 +209,7 @@ async function generateSBOM(
     const source = core.getInput("source");
     const relationship = core.getInput("relationship");
     const active = core.getInput("active");
+    const deactivateOlder = core.getInput("deactivate-older");
     const enrich = core.getInput("enrich");
     const assetLabels =
       core.getInput("sbomLabels") ||
@@ -284,6 +285,9 @@ async function generateSBOM(
       }
       if (active) {
         publishCommandParts.push(`--active="${active}"`);
+      }
+      if (deactivateOlder === "true") {
+        publishCommandParts.push(`--deactivate-older`);
       }
       if (enrich) {
         publishCommandParts.push(`--enrich="${enrich.toUpperCase()}"`);


### PR DESCRIPTION
Exposes the manifest-cli --deactivate-older flag as a new action input so callers can mark previous versions of an asset as inactive on publish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new optional configuration input to control whether older asset versions are deactivated during SBOM publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->