### PR TITLE
feat: add deactivate-label and replace-in-product inputs [CAP-2374]

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,27 @@ The product ID to associate the SBOM with.
 
 A comma separated list of labels to apply to the SBOM product, will only be applied if the product-id is set.
 
+### `deactivate-older`
+
+**Optional**
+`{STRING}`
+
+Mark previous versions of this asset as inactive when publishing this SBOM. Expects either `true` or `false`.
+
+### `deactivate-label`
+
+**Optional**
+`{STRING}`
+
+A comma separated list of labels that scopes `deactivate-older`. When set, only previous versions of this asset carrying one of these labels are deactivated; versions with other labels stay active. Requires `deactivate-older` to be `true`.
+
+### `replace-in-product`
+
+**Optional**
+`{STRING}`
+
+After upload, replace the asset's prior version in the product inventory with this version. Requires `product-id` to be set. Expects either `true` or `false`.
+
 ### `sbomGeneratorFlags`
 
 **Optional**

--- a/action.yml
+++ b/action.yml
@@ -89,6 +89,14 @@ inputs:
     description: "Mark previous versions of this asset as inactive when publishing this SBOM. Expects either `true` or `false`."
     required: false
 
+  deactivate-label:
+    description: "A comma separated list of labels that scopes `deactivate-older`. When set, only previous versions of this asset carrying one of these labels are deactivated. Requires `deactivate-older` to be `true`."
+    required: false
+
+  replace-in-product:
+    description: "After upload, replace the asset's prior version in the product inventory with this version. Requires `product-id` to be set. Expects either `true` or `false`."
+    required: false
+
   apiUri:
     description: "set the Manifest API endpoint URI."
     required: false

--- a/index.js
+++ b/index.js
@@ -222,7 +222,7 @@ async function generateSBOM(
     const relationship = core.getInput("relationship");
     const active = core.getInput("active");
     const deactivateOlder = core.getInput("deactivate-older");
-    const deactivateLabels = core.getInput("deactivate-label") || "";
+    const deactivateLabels = core.getInput("deactivate-label");
     const replaceInProduct = core.getInput("replace-in-product");
     const enrich = core.getInput("enrich");
     const assetLabels =

--- a/index.js
+++ b/index.js
@@ -222,6 +222,8 @@ async function generateSBOM(
     const relationship = core.getInput("relationship");
     const active = core.getInput("active");
     const deactivateOlder = core.getInput("deactivate-older");
+    const deactivateLabels = core.getInput("deactivate-label") || "";
+    const replaceInProduct = core.getInput("replace-in-product");
     const enrich = core.getInput("enrich");
     const assetLabels =
       core.getInput("sbomLabels") ||
@@ -310,6 +312,9 @@ async function generateSBOM(
       if (deactivateOlder === "true") {
         publishCommandParts.push(`--deactivate-older`);
       }
+      if (replaceInProduct === "true") {
+        publishCommandParts.push(`--replace-in-product`);
+      }
       if (enrich) {
         publishCommandParts.push(`--enrich="${enrich.toUpperCase()}"`);
       }
@@ -331,6 +336,14 @@ async function generateSBOM(
         .filter((label) => label !== "")
         .join(",")}"`;
       publishCommand = `${publishCommand} --product-id="${productId}"`;
+      const cleanedDeactivateLabels = deactivateLabels
+        .split(",")
+        .map((label) => label.trim())
+        .filter((label) => label !== "")
+        .join(",");
+      if (cleanedDeactivateLabels) {
+        publishCommand = `${publishCommand} --deactivate-label="${cleanedDeactivateLabels}"`;
+      }
       core.info("Sending request to Manifest Server");
       await execWrapper(publishCommand);
     } else {


### PR DESCRIPTION
## Summary

The Action already passes through `product-id` and `deactivate-older` to `manifest-cli publish`, but did not expose two related CLI flags. This adds them as inputs:

- **`deactivate-label`** → `--deactivate-label` — a comma-separated list of labels that scopes `deactivate-older`. When set, only previous versions of the asset carrying one of those labels are deactivated; versions with other labels stay active. Requires `deactivate-older: true` (enforced by the CLI).
- **`replace-in-product`** → `--replace-in-product` — after upload, replace the asset's prior version in the product inventory with this version. Requires `product-id` (enforced by the CLI).

## Changes

- `action.yml` — define the two new inputs.
- `index.js` — read both inputs and wire them into the publish command, following existing patterns: `--replace-in-product` appended next to `--deactivate-older`; `--deactivate-label` cleaned via the same split/trim/filter/join used for `asset-label` and only emitted when non-empty.
- `README.md` — document both inputs, plus backfill the previously undocumented `deactivate-older`.

## Example

```yaml
- uses: manifest-cyber/manifest-github-action@main
  with:
    apiKey: ${{ secrets.MANIFEST_API_KEY }}
    product-id: "abc123"
    replace-in-product: "true"
    deactivate-older: "true"
    deactivate-label: "production"
```

## Notes

- These mirror the CLI flag prerequisites: `--deactivate-label` requires `--deactivate-older`, and `--replace-in-product` requires `--product-id`. When a prerequisite is missing the CLI surfaces a clear validation error.
- `index.js` passes `node --check`. Not run end-to-end (would download the CLI and hit the live API).

Closes CAP-2374

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added publishing controls: deactivate-older (mark prior SBOMs inactive), deactivate-label (optional label scoping), and replace-in-product (optionally replace prior version in product inventory; requires product ID).
  * Label scoping accepts multiple labels.

* **Documentation**
  * README updated to document the three new inputs and their usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manifest-cyber/manifest-github-action/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->