### PR TITLE
fix: ENG-86: fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Manifest Github Action
 
-Use this action to generator and/or upload a generated SBOM to your Manifest account. **Requires a Manifest API key.**
+Use this action to generate and/or upload a generated SBOM to your Manifest account. **Requires a Manifest API key.**
 
 This action will also install all required dependencies including generators, signers etc.
 


### PR DESCRIPTION
Linear ticket: https://linear.app/manifest-cyber/issue/ENG-86/ess-correct-minor-typo-in-gh-action-readme

It should be "generate and/or upload" instead of "generator and/or upload"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected phrasing in the GitHub Action documentation regarding SBOM generation and upload functionality for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manifest-cyber/manifest-github-action/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->