### PR TITLE
Update workflow actions off Node 20 runtime

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     name: Generate SBOM
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Generate SBOM
         uses: manifest-cyber/manifest-github-action@main

--- a/action.yml
+++ b/action.yml
@@ -142,5 +142,5 @@ inputs:
     description: "The name of the SBOM artifact. Defaults to the 'sbom'"
     required: false
 runs:
-  using: "node20"
+  using: "node24"
   main: "index.js"


### PR DESCRIPTION
PLAT-2209. Bumps workflow actions off the deprecated Node 20 runtime to Node 24 versions, SHA-pinned to the commit each tag resolves to.

| Action | To |
|---|---|
| actions/checkout | `93cb6ef` # v5.0.1 |

Also bumps this action’s own runtime in `action.yml` from `node20` to `node24`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow now pins the repository checkout step to a specific, immutable version.
  * Action runtime upgraded to Node.js 24 for the automated workflow environment.

---

Note: These are infrastructure updates only and do not introduce user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->